### PR TITLE
Add systemd DefaultEnvironment

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,0 +1,3 @@
+- name: systemd daemon-reload
+  ansible.builtin.systemd:
+    daemon_reload: yes

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -32,6 +32,29 @@
     mode: u=rw,g=r,o=r
   tags: proxy
 
+- name: Check if systemd/system.conf exists
+  ansible.builtin.stat:
+    path: /etc/systemd/system.conf
+  register: systemd_system_conf
+  tags: proxy
+
+- name: Configure proxy settings for systemd services
+  ansible.builtin.lineinfile:
+    path: /etc/systemd/system.conf
+    regexp: "^DefaultEnvironment="
+    line: >-
+      DefaultEnvironment={% if proxy_settings_ftp_proxy is defined %}"FTP_PROXY={{ proxy_settings_ftp_proxy }}"{% endif %}
+      {% if proxy_settings_http_proxy is defined %}"HTTP_PROXY={{ proxy_settings_http_proxy }}"{% endif %}
+      {% if proxy_settings_https_proxy is defined %}"HTTPS_PROXY={{ proxy_settings_https_proxy }}"{% endif %}
+      {% if proxy_settings_no_proxy is defined %}"NO_PROXY={{ proxy_settings_no_proxy }}"{% endif %}
+      {% if proxy_settings_ftp_proxy is defined %}"ftp_proxy={{ proxy_settings_ftp_proxy }}"{% endif %}
+      {% if proxy_settings_http_proxy is defined %}"http_proxy={{ proxy_settings_http_proxy }}"{% endif %}
+      {% if proxy_settings_https_proxy is defined %}"https_proxy={{ proxy_settings_https_proxy }}"{% endif %}
+      {% if proxy_settings_no_proxy is defined %}"no_proxy={{ proxy_settings_no_proxy }}"{% endif %}
+  when: systemd_system_conf.stat.exists
+  notify: systemd daemon-reload
+  tags: proxy
+
 - name: Check if wgetrc exists
   stat:
     path: /etc/wgetrc


### PR DESCRIPTION
Systemd services do not pick up settings from /etc/environment. Instead,
you need to either configure each service individually, or add
environment variables to the global configuration as DefaultEnvironment
to /etc/systemd/system.conf.

See https://www.freedesktop.org/software/systemd/man/systemd-system.conf.html